### PR TITLE
Update memory sizes for small and medium configurations

### DIFF
--- a/environment/terraform.tfvars
+++ b/environment/terraform.tfvars
@@ -7,11 +7,11 @@ allowed_cidr_blocks = [
 sizes = {
   small = {
     cpu    = 4096
-    memory = 4096
+    memory = 8192
   }
   medium = {
     cpu    = 4096
-    memory = 8192
+    memory = 16384
   }
   large = {
     cpu    = 8192


### PR DESCRIPTION
This pull request increases the memory allocation for the `small` and `medium` instance sizes in the `terraform.tfvars` configuration file.

Resource configuration updates:

* Increased the `memory` for the `small` size from 4096 to 8192.
* Increased the `memory` for the `medium` size from 8192 to 16384.