### PR TITLE
Simplify message building for ECS task notifications and reduce logging

### DIFF
--- a/lambda/ecs-task-notify/index.mjs
+++ b/lambda/ecs-task-notify/index.mjs
@@ -33,10 +33,10 @@ function buildSimpleMessage(event) {
     const status = event?.detail?.lastStatus;
 
     if (status === "RUNNING") {
-        return "✅ サーバー起動開始しました";
+        return "✅ サーバー起動開始しました。数分後にサーバーに接続できます。";
     }
     if (status === "STOPPED") {
-        return "🛑 サーバー停止しました";
+        return "🛑 サーバー停止しました。";
     }
     return null; // ignore others
 }


### PR DESCRIPTION
This pull request simplifies the notification logic in `lambda/ecs-task-notify/index.mjs` for ECS task state changes, focusing only on "RUNNING" and "STOPPED" events and providing concise, localized messages. It removes detailed status reporting and unnecessary environment variable checks, resulting in a cleaner and more maintainable codebase.

Notification logic simplification:

* Replaced the verbose `buildMessage` function with a new `buildSimpleMessage` function that returns short, localized messages only for "RUNNING" and "STOPPED" statuses, ignoring all other statuses.
* Removed environment variable checks (`NOTIFY_ON_RUNNING` and `NOTIFY_ON_STOPPED`) and now only sends notifications for "RUNNING" and "STOPPED" events based on the simplified message function.

Logging and error handling cleanup:

* Reduced log output to only essential information when posting to the Discord webhook, making logs easier to read and maintain.
* Removed redundant comments and unnecessary lines in error handling to streamline the code.