### PR TITLE
Issue/update minecraft cpu memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,9 @@ NLB DNS名はAWS Consoleで確認できます（下記参照）。
 
 ```hcl
 sizes = {
-  small  = { cpu = 1024, memory = 2048 }   # 1vCPU, 2GB RAM
-  medium = { cpu = 2048, memory = 4096 }   # 2vCPU, 4GB RAM
-  large  = { cpu = 4096, memory = 8192 }   # 4vCPU, 8GB RAM
+  small  = { cpu = 2048, memory = 8192  }   # 2vCPU, 8GB RAM
+  medium = { cpu = 4096, memory = 16384 }   # 4vCPU, 16GB RAM
+  large  = { cpu = 8192, memory = 32768 }   # 8vCPU, 32GB RAM
 }
 ```
 

--- a/environment/terraform.tfvars
+++ b/environment/terraform.tfvars
@@ -10,7 +10,7 @@ allowed_cidr_blocks = [
 # サイズ定義（必要なら調整）
 sizes = {
   small = {
-    cpu    = 4096
+    cpu    = 2048
     memory = 8192
   }
   medium = {
@@ -19,7 +19,7 @@ sizes = {
   }
   large = {
     cpu    = 8192
-    memory = 16384
+    memory = 32768
   }
 }
 


### PR DESCRIPTION
This pull request updates resource sizing in the `environment/terraform.tfvars` file to better align with current usage requirements. The most important changes are adjustments to the CPU and memory allocations for the `small` and `large` instance size definitions.

Resource sizing updates:

* Reduced the `cpu` allocation for the `small` size from 4096 to 2048 in `sizes`.
* Increased the `memory` allocation for the `large` size from 16384 to 32768 in `sizes`.


https://github.com/YumaIshikawa18/minecraft-aws-terraform-demo/issues/27